### PR TITLE
Fixed Docstring

### DIFF
--- a/pynbt/nbt.py
+++ b/pynbt/nbt.py
@@ -297,7 +297,7 @@ class NBTFile(TAG_Compound):
         >>> nbt = NBTFile(name='')
 
         Whereas loading an existing one is most often done:
-        >>> with open('my_file.nbt', rb') as io:
+        >>> with open('my_file.nbt', 'rb') as io:
         ...     nbt = NBTFile(io=io)
         """
         # No file or path given, so we're creating a new NBTFile.


### PR DESCRIPTION
Need this
```
>>> with open('my_file.nbt', 'rb') as io:
```
But excepted:
```
>>> with open('my_file.nbt', rb') as io:
```
at here https://github.com/TkTech/PyNBT/blob/b1599f91493b237cf1e135b280d73a5038215a96/pynbt/nbt.py#L300