### PR TITLE
fix errors involving multi-byte characters 

### DIFF
--- a/pynbt.py
+++ b/pynbt.py
@@ -30,7 +30,7 @@ class BaseTag(object):
     def _read_utf8(read):
         """Reads a length-prefixed UTF-8 string."""
         name_length = read('h', 2)[0]
-        return read.src.read(name_length).decode('utf-8')
+        return read.src.read(name_length).decode('utf-8', 'surrogatepass')
 
     @staticmethod
     def _write_utf8(write, value):

--- a/pynbt.py
+++ b/pynbt.py
@@ -35,7 +35,7 @@ class BaseTag(object):
     @staticmethod
     def _write_utf8(write, value):
         """Writes a length-prefixed UTF-8 string."""
-        b = value.encode('utf-8')
+        b = value.encode('utf-8', 'surrogatepass')
         write('h', len(b))
         write.dst.write(b)
 

--- a/pynbt.py
+++ b/pynbt.py
@@ -35,8 +35,9 @@ class BaseTag(object):
     @staticmethod
     def _write_utf8(write, value):
         """Writes a length-prefixed UTF-8 string."""
-        write('h', len(value))
-        write.dst.write(value.encode('utf-8'))
+        b = value.encode('utf-8')
+        write('h', len(b))
+        write.dst.write(b)
 
     @classmethod
     def read(cls, read, has_name=True):

--- a/pynbt.py
+++ b/pynbt.py
@@ -30,7 +30,8 @@ class BaseTag(object):
     def _read_utf8(read):
         """Reads a length-prefixed UTF-8 string."""
         name_length = read('h', 2)[0]
-        return read.src.read(name_length).decode('utf-8', 'surrogatepass')
+        value = read.src.read(name_length).replace(b'\xc0\x80', b'\x00')
+        return value.decode('utf-8', 'surrogatepass')
 
     @staticmethod
     def _write_utf8(write, value):


### PR DESCRIPTION
When writing a `TAG_String`, the prefixed length will not correspond to the actual byte length if there are multi-byte characters present.

The string `❤` is translated into the following bytes:
```
01 e2 9d a4
```
Expected:
```
03 e2 9d a4
```
This is easily fixed by writing the byte length instead of the actual character count.

Additionally, the `surrogatepass` error handler should be used to allow for encoding and decoding of Unicode characters in the range `0x10000` to `0x10FFFF`.

Lastly, NBT tags use [Modified UTF-8](https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8l) and null bytes are encoded as `0xc0 0x80`. They must be converted to the standard `0x00` null bytes before an attempt to decode is made.